### PR TITLE
Refact: take into account the new specifications

### DIFF
--- a/src/main/java/com/codingame/codemachine/runner/junit/JUnitTestListRunner.java
+++ b/src/main/java/com/codingame/codemachine/runner/junit/JUnitTestListRunner.java
@@ -3,7 +3,7 @@ package com.codingame.codemachine.runner.junit;
 public class JUnitTestListRunner {
     public static void main(String... args) {
         JUnitTest jUnitTest = new JUnitTest();
-        int statusCode = jUnitTest.run(args);
+        int statusCode = jUnitTest.run(args[0]);
         System.exit(statusCode);
     }
 }

--- a/src/main/java/com/codingame/codemachine/runner/junit/TestResultDtoFactory.java
+++ b/src/main/java/com/codingame/codemachine/runner/junit/TestResultDtoFactory.java
@@ -30,15 +30,10 @@ class TestResultDtoFactory {
         return runLog;
     }
 
-    TestResultDto create(boolean success, Description description, Throwable t) {
+    TestResultDto create(boolean success, Throwable t) {
         TestResultDto result = new TestResultDto();
         result.setSuccess(success);
         result.setNotFound(false);
-        String testReference = description.getClassName();
-        if (description.getMethodName() != null) {
-            testReference += "#" + description.getMethodName();
-        }
-        result.setTestReference(testReference);
         if (t != null) {
             result.setLogs(singletonList(parseThrowable(t)));
         }

--- a/src/main/java/com/codingame/codemachine/runner/junit/TestResultProvider.java
+++ b/src/main/java/com/codingame/codemachine/runner/junit/TestResultProvider.java
@@ -7,22 +7,22 @@ import org.junit.runner.notification.RunListener;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.List;
 
 public class TestResultProvider extends RunListener {
     private final TestResultDtoFactory testResultDtoFactory;
-    private final List<TestResultDto> results;
+    private final TestResultDto result;
 
     private ByteArrayOutputStream out;
     private ByteArrayOutputStream err;
     private TestResultDto currentResult;
 
-    TestResultProvider(List<TestResultDto> results) {
-        this(results, null);
+    TestResultProvider(TestResultDto result) {
+        this(result, null);
     }
 
-    TestResultProvider(List<TestResultDto> results, TestResultDtoFactory testResultDtoFactory) {
-        this.results = results;
+    TestResultProvider(TestResultDto result, TestResultDtoFactory testResultDtoFactory) {
+        this.result = result;
+        this.result.setSuccess(true);
         this.testResultDtoFactory = testResultDtoFactory != null ? testResultDtoFactory : new TestResultDtoFactory();
     }
 
@@ -35,16 +35,17 @@ public class TestResultProvider extends RunListener {
     }
 
     public void testFailure(Failure failure) {
-        currentResult = testResultDtoFactory.create(false, failure.getDescription(), failure.getException());
+        currentResult = testResultDtoFactory.create(false, failure.getException());
     }
 
     public void testFinished(Description description) throws Exception {
         if (currentResult == null) {
-            currentResult = testResultDtoFactory.create(true, description, null);
+            currentResult = testResultDtoFactory.create(true, null);
         }
-        currentResult.setProgramStderr(new String(err.toByteArray()));
-        currentResult.setProgramStdout(new String(out.toByteArray()));
-        results.add(currentResult);
+        result.appendStderr(new String(err.toByteArray()));
+        result.appendStdout(new String(out.toByteArray()));
+        result.appendLogs(currentResult.getLogs());
+        result.setSuccess(result.isSuccess() && currentResult.isSuccess());
         err.close();
         out.close();
     }

--- a/src/main/java/com/codingame/codemachine/runner/junit/core/TestResultDto.java
+++ b/src/main/java/com/codingame/codemachine/runner/junit/core/TestResultDto.java
@@ -1,22 +1,14 @@
 package com.codingame.codemachine.runner.junit.core;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestResultDto {
-    private String testReference;
     private boolean success;
     private boolean notFound;
     private List<RunLogDto> logs;
-    private String programStdout;
-    private String programStderr;
-
-    public String getTestReference() {
-        return testReference;
-    }
-
-    public void setTestReference(String testReference) {
-        this.testReference = testReference;
-    }
+    private String stdout = "";
+    private String stderr = "";
 
     public boolean isSuccess() {
         return success;
@@ -27,11 +19,18 @@ public class TestResultDto {
     }
 
     public List<RunLogDto> getLogs() {
+        if (logs == null) {
+            setLogs(new ArrayList<>());
+        }
         return logs;
     }
 
     public void setLogs(List<RunLogDto> logs) {
         this.logs = logs;
+    }
+
+    public void appendLogs(List<RunLogDto> logs) {
+        getLogs().addAll(logs);
     }
 
     public boolean isNotFound() {
@@ -42,19 +41,27 @@ public class TestResultDto {
         this.notFound = notFound;
     }
 
-    public String getProgramStdout() {
-        return programStdout;
+    public String getStdout() {
+        return stdout;
     }
 
-    public void setProgramStdout(String programStdout) {
-        this.programStdout = programStdout;
+    public void setStdout(String stdout) {
+        this.stdout = stdout;
     }
 
-    public String getProgramStderr() {
-        return programStderr;
+    public void appendStdout(String stdsout) {
+        setStdout(getStdout() + stdsout);
     }
 
-    public void setProgramStderr(String programStderr) {
-        this.programStderr = programStderr;
+    public String getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(String stderr) {
+        this.stderr = stderr;
+    }
+
+    public void appendStderr(String stderr) {
+        setStderr(getStderr() + stderr);
     }
 }

--- a/src/main/resources/junit-runner
+++ b/src/main/resources/junit-runner
@@ -10,7 +10,7 @@ find * -name "*.java" -print0 | xargs -0 /usr/src/codingame/java-compiler/cgjava
 compilationExitCode=$?
 
 if [ $compilationExitCode -eq 0 ]; then
-	java -cp "/project/workspace:$classpath:/usr/src/codingame/junit-runner/junit-runner.jar" -Dcodingame.junit-runner.output=/project/results/executions.json com.codingame.codemachine.runner.junit.JUnitTestListRunner $*
+	java -cp "/project/workspace:$classpath:/usr/src/codingame/junit-runner/junit-runner.jar" -Dcodingame.junit-runner.output=/project/results/execution.json com.codingame.codemachine.runner.junit.JUnitTestListRunner $*
 	executionExitCode=$?
 fi
 

--- a/src/test/java/com/codingame/codemachine/runner/junit/TestJunitTest.java
+++ b/src/test/java/com/codingame/codemachine/runner/junit/TestJunitTest.java
@@ -4,8 +4,6 @@ import com.codingame.codemachine.runner.junit.JUnitTest.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJunitTest {
@@ -26,9 +24,8 @@ public class TestJunitTest {
     @Test
     public void should_not_find_test_class_if_it_does_not_exist() throws ClassNotFoundException {
         String className = "unknown.ClassTest";
-        List<TestCase> testCases = jUnitTest.findRequests(className);
-        assertThat(testCases).hasSize(1);
-        assertThat(testCases.get(0).exists()).isFalse();
+        TestCase testCase = jUnitTest.findRequest(className);
+        assertThat(testCase.exists()).isFalse();
     }
 
     @Test
@@ -36,32 +33,6 @@ public class TestJunitTest {
         String className = "resources.simple.com.codingame.core.MyFirstTest";
         String methodName = "myFirstTest";
         checkTestCase(className, methodName);
-    }
-
-    @Test
-    public void should_find_many_test_methods() {
-        String className = "resources.simple.com.codingame.core.MyFirstTest";
-        String methodName0 = "myFirstTest";
-        String methodName1 = "aSecondTest";
-        List<TestCase> testCases =
-            jUnitTest.findRequests(className + "#" + methodName0, className + "#" + methodName1);
-        assertThat(testCases).hasSize(2);
-        assertThat(testCases.get(0).exists()).isTrue();
-        assertThat(testCases.get(0).description()).isEqualTo(className + "#" + methodName0);
-        assertThat(testCases.get(1).exists()).isTrue();
-        assertThat(testCases.get(1).description()).isEqualTo(className + "#" + methodName1);
-    }
-
-    @Test
-    public void should_find_many_test_methods_even_with_errors() {
-        String className = "resources.simple.com.codingame.core.MyFirstTest";
-        String methodName0 = "myFirstTest";
-        String methodName1 = "unknown";
-        List<TestCase> testCases =
-            jUnitTest.findRequests(className + "#" + methodName0, className + "#" + methodName1);
-        assertThat(testCases).hasSize(2);
-        assertThat(testCases.get(0).exists()).isTrue();
-        assertThat(testCases.get(1).exists()).isFalse();
     }
 
     @Test
@@ -75,42 +46,29 @@ public class TestJunitTest {
     public void does_not_work_with_parameterized_test_class() {
         String className = "resources.parameterized.com.codingame.core.FibonacciTest";
         String methodName = "test";
-        List<TestCase> testCases = jUnitTest.findRequests(className + "#" + methodName);
-        assertThat(testCases).hasSize(1);
-        assertThat(testCases.get(0).exists()).isFalse();
+        TestCase testCase = jUnitTest.findRequest(className + "#" + methodName);
+        assertThat(testCase).isNotNull();
+        assertThat(testCase.exists()).isFalse();
     }
 
     private void checkTestCase(String className) throws ClassNotFoundException {
-        List<TestCase> testCases = jUnitTest.findRequests(className);
-        assertThat(testCases).hasSize(1);
+        TestCase testCase = jUnitTest.findRequest(className);
+        assertThat(testCase).isNotNull();
 
         Class<?> clazz = Class.forName(className);
         int expectedTestCount = clazz.getDeclaredMethods().length;
-        assertThat(testCases.get(0).exists()).isTrue();
-        assertThat(testCases.get(0).description()).isEqualTo(className);
-        int testCount = testCases.get(0).request().getRunner().testCount();
+        assertThat(testCase.exists()).isTrue();
+        assertThat(testCase.description()).isEqualTo(className);
+        int testCount = testCase.request().getRunner().testCount();
         assertThat(testCount).isEqualTo(expectedTestCount);
     }
 
     private void checkTestCase(String className, String methodName) {
-        List<TestCase> testCases = jUnitTest.findRequests(className + "#" + methodName);
-        assertThat(testCases).hasSize(1);
-        assertThat(testCases.get(0).exists()).isTrue();
-        assertThat(testCases.get(0).description()).isEqualTo(className + "#" + methodName);
-        int testCount = testCases.get(0).request().getRunner().testCount();
+        TestCase testCase = jUnitTest.findRequest(className + "#" + methodName);
+        assertThat(testCase).isNotNull();
+        assertThat(testCase.exists()).isTrue();
+        assertThat(testCase.description()).isEqualTo(className + "#" + methodName);
+        int testCount = testCase.request().getRunner().testCount();
         assertThat(testCount).isEqualTo(1);
-    }
-
-    @Test
-    public void should_run_only_known_test_methods() {
-        String className = "resources.simple.com.codingame.core.MyFirstTest";
-        String methodName0 = "myFirstTest";
-        String methodName1 = "unknown";
-
-        JUnitTest jUnitTest = new JUnitTest();
-        List<TestCase> testCases = jUnitTest.findRequests(className + "#" + methodName0, className + "#" + methodName1);
-        jUnitTest.runTestCases(testCases);
-
-        assertThat(jUnitTest.isOneFailure()).isTrue();
     }
 }

--- a/src/test/java/com/codingame/codemachine/runner/junit/TestResultDtoFactoryTest.java
+++ b/src/test/java/com/codingame/codemachine/runner/junit/TestResultDtoFactoryTest.java
@@ -3,7 +3,6 @@ package com.codingame.codemachine.runner.junit;
 import com.codingame.codemachine.runner.junit.core.RunLogDto;
 import com.codingame.codemachine.runner.junit.core.TestResultDto;
 import org.junit.Test;
-import org.junit.runner.Description;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,45 +10,25 @@ public class TestResultDtoFactoryTest {
 
     @Test
     public void should_parse_a_simple_testsuite_success() {
-        String testCase = "com.codingame.test.MyTest";
-        Description testDescription = Description.createSuiteDescription(testCase);
-        TestResultDto testResultDto = new TestResultDtoFactory().create(true, testDescription, null);
+        TestResultDto testResultDto = new TestResultDtoFactory().create(true, null);
         assertThat(testResultDto.isSuccess()).isTrue();
         assertThat(testResultDto.isNotFound()).isFalse();
-        assertThat(testResultDto.getTestReference()).isEqualTo(testCase);
     }
 
     @Test
-    public void should_parse_a_simple_testcase_success() {
-        String className = "com.codingame.test.MyTest";
-        String test = "theTest";
-        Description testDescription = Description.createTestDescription(className, test);
-        TestResultDto testResultDto = new TestResultDtoFactory().create(true, testDescription, null);
-        assertThat(testResultDto.isSuccess()).isTrue();
-        assertThat(testResultDto.isNotFound()).isFalse();
-        assertThat(testResultDto.getTestReference()).isEqualTo(className + "#" + test);
-    }
-
-    @Test
-    public void should_parse_a_simple_fail() {
-        String testCase = "com.codingame.test.MyTest";
-        Description testDescription = Description.createSuiteDescription(testCase);
-        TestResultDto testResultDto = new TestResultDtoFactory().create(false, testDescription, null);
+    public void should_parse_a_simple_testsuite_fail() {
+        TestResultDto testResultDto = new TestResultDtoFactory().create(false, null);
         assertThat(testResultDto.isSuccess()).isFalse();
         assertThat(testResultDto.isNotFound()).isFalse();
-        assertThat(testResultDto.getTestReference()).isEqualTo(testCase);
     }
 
     @Test
     public void should_parse_a_full_fail() {
-        String testCase = "com.codingame.test.MyTest";
-        Description testDescription = Description.createSuiteDescription(testCase);
         RuntimeException cause = new RuntimeException("Cause");
         TestResultDto testResultDto =
-            new TestResultDtoFactory().create(false, testDescription, new Throwable("Problem", cause));
+            new TestResultDtoFactory().create(false, new Throwable("Problem", cause));
         assertThat(testResultDto.isSuccess()).isFalse();
         assertThat(testResultDto.isNotFound()).isFalse();
-        assertThat(testResultDto.getTestReference()).isEqualTo(testCase);
         assertThat(testResultDto.getLogs()).hasSize(1);
         RunLogDto runLogDto = testResultDto.getLogs().get(0);
         assertThat(runLogDto.getMessage()).isEqualTo("Problem");

--- a/src/test/java/com/codingame/codemachine/runner/junit/TestResultProviderTest.java
+++ b/src/test/java/com/codingame/codemachine/runner/junit/TestResultProviderTest.java
@@ -1,13 +1,12 @@
 package com.codingame.codemachine.runner.junit;
 
+import com.codingame.codemachine.runner.junit.core.RunLogDto;
 import com.codingame.codemachine.runner.junit.core.TestResultDto;
-import junit.framework.TestFailure;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -17,16 +16,16 @@ public class TestResultProviderTest {
 
     @Test
     public void should_create_TestResultDto_when_testFinished() throws Exception {
+        TestResultDtoFactory testResultDtoFactory = mock(TestResultDtoFactory.class);
+        TestResultDto result = new TestResultDto();
+        TestResultProvider testResultProvider = new TestResultProvider(result, testResultDtoFactory);
+        TestResultDto testResultDto = new TestResultDto();
+        testResultDto.setSuccess(true);
+        when(testResultDtoFactory.create(true, null)).thenReturn(testResultDto);
+
         String className = "com.codingame.test.MyTest";
         String test = "theTest";
         Description testDescription = Description.createTestDescription(className, test);
-
-        TestResultDtoFactory testResultDtoFactory = mock(TestResultDtoFactory.class);
-        List<TestResultDto> results = new ArrayList<>();
-        TestResultProvider testResultProvider = new TestResultProvider(results, testResultDtoFactory);
-        TestResultDto testResultDto = new TestResultDto();
-        when(testResultDtoFactory.create(true, testDescription, null)).thenReturn(testResultDto);
-
         testResultProvider.testStarted(testDescription);
         String stdOutput = "This is a test output on stdout";
         System.out.println(stdOutput);
@@ -34,33 +33,34 @@ public class TestResultProviderTest {
         System.err.println(stdError);
         testResultProvider.testFinished(testDescription);
 
-        assertThat(results).hasSize(1);
-        TestResultDto actualTestResultDto = results.get(0);
-        assertThat(actualTestResultDto).isSameAs(testResultDto);
-        assertThat(actualTestResultDto.getProgramStdout()).isEqualTo(stdOutput + "\n");
-        assertThat(actualTestResultDto.getProgramStderr()).isEqualTo(stdError + "\n");
+        assertThat(result.getStdout()).isEqualTo(stdOutput + "\n");
+        assertThat(result.getStderr()).isEqualTo(stdError + "\n");
+        assertThat(result.isSuccess()).isTrue();
     }
 
     @Test
     public void should_create_TestResultDto_when_testFailure() throws Exception {
+        TestResultDtoFactory testResultDtoFactory = mock(TestResultDtoFactory.class);
+        TestResultDto result = new TestResultDto();
+        TestResultProvider testResultProvider = new TestResultProvider(result, testResultDtoFactory);
+        Throwable problem = new Throwable("Problem");
+        RunLogDto log = new RunLogDto();
+        log.setMessage("Fake Log");
+        TestResultDto testResultDto = new TestResultDto();
+        testResultDto.setLogs(Collections.singletonList(log));
+        testResultDto.setSuccess(false);
+        when(testResultDtoFactory.create(false, problem)).thenReturn(testResultDto);
+
         String className = "com.codingame.test.MyTest";
         String test = "theTest";
         Description testDescription = Description.createTestDescription(className, test);
-
-        TestResultDtoFactory testResultDtoFactory = mock(TestResultDtoFactory.class);
-        List<TestResultDto> results = new ArrayList<>();
-        TestResultProvider testResultProvider = new TestResultProvider(results, testResultDtoFactory);
-        Throwable problem = new Throwable("Problem");
-        TestResultDto testResultDto = new TestResultDto();
-        when(testResultDtoFactory.create(false, testDescription, problem)).thenReturn(testResultDto);
-
         Failure failure = new Failure(testDescription, problem);
         testResultProvider.testStarted(testDescription);
         testResultProvider.testFailure(failure);
         testResultProvider.testFinished(testDescription);
 
-        assertThat(results).hasSize(1);
-        TestResultDto actualTestResultDto = results.get(0);
-        assertThat(actualTestResultDto).isSameAs(testResultDto);
+        assertThat(result.getLogs()).hasSize(1);
+        assertThat(result.getLogs().get(0).getMessage()).isEqualTo("Fake Log");
+        assertThat(result.isSuccess()).isFalse();
     }
 }


### PR DESCRIPTION
In this version of specifications, only one testcase could be launched and the result is written in the `execution.json` file (instead of `executions.json`).
Furthermore, some json property names have changed and the `testReference` is no more needed.